### PR TITLE
GitHub Actions Improvements

### DIFF
--- a/.github/workflows/Build-iOS.yml
+++ b/.github/workflows/Build-iOS.yml
@@ -1,6 +1,10 @@
 name: Build-iOS
 on:
   pull_request:
+
+  # Allow actions to be run manually
+  workflow_dispatch:
+
 jobs:
   test:
     name: Build and test

--- a/.github/workflows/Build-iOS.yml
+++ b/.github/workflows/Build-iOS.yml
@@ -3,6 +3,12 @@ name: Build-iOS
 
 "on":
   pull_request:
+    branches:
+      - $default-branch
+
+  push:
+    branches:
+      - $default-branch
 
   # Allow actions to be run manually
   workflow_dispatch:

--- a/.github/workflows/Build-iOS.yml
+++ b/.github/workflows/Build-iOS.yml
@@ -1,5 +1,7 @@
+---
 name: Build-iOS
-on:
+
+"on":
   pull_request:
 
   # Allow actions to be run manually
@@ -9,23 +11,34 @@ jobs:
   test:
     name: Build and test
     runs-on: macOS-latest
+
     strategy:
-        matrix:
-          destination: ['platform=iOS Simulator,OS=13.7,name=iPhone 11']
+      matrix:
+        destination: ["platform=iOS Simulator,OS=13.7,name=iPhone 11"]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Force XCode 11.7
         run: sudo xcode-select -switch /Applications/Xcode_11.7.app
+
       - name: Build
         run: |
           cd HPHC
-          xcodebuild clean build -workspace HPHC.xcworkspace -scheme HPHC -destination "${destination}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES
+          xcodebuild clean build \
+            -workspace HPHC.xcworkspace \
+            -scheme HPHC \
+            -destination "${{ matrix.destination }}"
         env:
-         destination: ${{ matrix.destination }}
+          CODE_SIGN_IDENTITY: ""
+          CODE_SIGNING_REQUIRED: "NO"
+          ONLY_ACTIVE_ARCH: "YES"
+
       - name: Test
         run: |
           cd HPHC
-          xcodebuild test -workspace HPHC.xcworkspace -scheme HPHC -destination "${destination}"
-        env:
-         destination: ${{ matrix.destination }}
+          xcodebuild test \
+            -workspace HPHC.xcworkspace \
+            -scheme HPHC \
+            -destination "${{ matrix.destination }}"

--- a/.github/workflows/Build-iOS.yml
+++ b/.github/workflows/Build-iOS.yml
@@ -17,11 +17,11 @@ jobs:
         run: |
           cd HPHC
           xcodebuild clean build -workspace HPHC.xcworkspace -scheme HPHC -destination "${destination}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES
-        env: 
+        env:
          destination: ${{ matrix.destination }}
       - name: Test
         run: |
           cd HPHC
           xcodebuild test -workspace HPHC.xcworkspace -scheme HPHC -destination "${destination}"
-        env: 
+        env:
          destination: ${{ matrix.destination }}

--- a/.github/workflows/lint-iOS.yml
+++ b/.github/workflows/lint-iOS.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - Develop
 
+  # Allow actions to be run manually
+  workflow_dispatch:
+
 jobs:
   SwiftLint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-iOS.yml
+++ b/.github/workflows/lint-iOS.yml
@@ -4,7 +4,11 @@ name: SwiftLint
 "on":
   pull_request:
     branches:
-      - Develop
+      - $default-branch
+
+  push:
+    branches:
+      - $default-branch
 
   # Allow actions to be run manually
   workflow_dispatch:

--- a/.github/workflows/lint-iOS.yml
+++ b/.github/workflows/lint-iOS.yml
@@ -1,6 +1,7 @@
+---
 name: SwiftLint
 
-on:
+"on":
   pull_request:
     branches:
       - Develop

--- a/.github/workflows/lint-iOS.yml
+++ b/.github/workflows/lint-iOS.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - Develop
-    
+
 jobs:
   SwiftLint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adds a number of nice things to the GitHub Actions:
  - allows them to be run manually from the "Actions" tab of the repo
  - cleaned up the formatting using [yamllint](https://github.com/adrienverge/yamllint)
  - no more extra long lines
  - `matrix.destination` values added directly to `xcodebuild` command
  - run actions for both PRs against the default branch and pushes to the default branch